### PR TITLE
feat: add write access and payment tools (10 new MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,70 +5,53 @@ An MCP server implementation that integrates with Lexware Office (formerly known
 ## Features
 
 - **Lexware Office Integration**: Direct integration with the Lexware Office API
-- **Business Operations**: Manage invoices, contacts, and other business documents (read-only as of now)
+- **Business Operations**: Manage invoices, contacts, vouchers, and other business documents
 
 ## Tools
 
 The following tools are available through this MCP server:
 
-- **get-invoices**
+| Tool | Description | API |
+|---|---|---|
+| `get-invoices` | Get a list of invoices from Lexware Office | `GET /v1/invoices` |
+| `get-invoice-details` | Get details of a specific invoice | `GET /v1/invoices/{id}` |
+| `get-contacts` | Get contacts with optional filters | `GET /v1/contacts` |
+| `get-vouchers` | Get a list of bookkeeping vouchers | `GET /v1/voucherlist` |
+| `get-voucher-details` | Get details of a specific bookkeeping voucher | `GET /v1/vouchers/{id}` |
+| `get-file` | Download a file (PDF or XML) by file ID | `GET /v1/files/{id}` |
+| `list-posting-categories` | List posting categories for bookkeeping vouchers | `GET /v1/posting-categories` |
+| `list-countries` | List countries with their tax classifications | `GET /v1/countries` |
+| `get-payments` | Get payment information for an invoice or voucher | `GET /v1/payments` |
+| `get-payment-conditions` | List available payment conditions (Zahlungsbedingungen) | `GET /v1/payment-conditions` |
+| `create-contact` | Create a new contact (customer or vendor) | `POST /v1/contacts` |
+| `update-contact` | Update an existing contact | `PUT /v1/contacts/{id}` |
+| `create-invoice` | Create an invoice as a draft | `POST /v1/invoices` |
+| `finalize-invoice` | Create and immediately finalize an invoice | `POST /v1/invoices?finalize=true` |
+| `create-dunning` | Create a dunning notice (Mahnung) as a draft | `POST /v1/dunnings` |
+| `finalize-dunning` | Create and immediately finalize a dunning notice | `POST /v1/dunnings?finalize=true` |
+| `create-voucher` | Create a bookkeeping voucher (Buchungsbeleg) | `POST /v1/vouchers` |
+| `update-voucher` | Update an existing bookkeeping voucher | `PUT /v1/vouchers/{id}` |
 
-  - Get a list of invoices from Lexware Office
-  - Inputs:
-    - `status` (array of strings, optional): Filter by invoice status ("open", "draft", "paid", "paidoff", "voided"). Default: all statuses
-    - `page` (number, optional): Page number to retrieve (starts at 0). Default: 0
-    - `size` (number, optional): Number of invoices per page (1-250). Default: 250
+## Permission Model
 
-- **get-invoice-details**
+Tools are grouped into three tiers. You can restrict access by disabling tools in your Claude/MCP configuration:
 
-  - Get details of an invoice from Lexware Office
-  - Inputs:
-    - `id` (string): The UUID of the invoice
+| Tier | Allowed | Disable these tools |
+|---|---|---|
+| Read-only | All `get-*` and `list-*` tools | `create-*`, `update-*`, `finalize-*` |
+| Draft mode | + create/update tools | `finalize-invoice`, `finalize-dunning` |
+| Full access | All tools | _(nothing)_ |
 
-- **get-contacts**
-
-  - Get contacts from Lexware Office with optional filters that are combined with a logical AND
-  - Inputs:
-    - `email` (string, optional): Filter contacts by email address (supports wildcards)
-    - `name` (string, optional): Filter contacts by name (supports wildcards)
-    - `number` (number, optional): Filter contacts by contact number
-    - `customer` (boolean, optional): Filter contacts by customer role
-    - `vendor` (boolean, optional): Filter contacts by vendor role
-    - `page` (number, optional): Page number to retrieve (starts at 0). Default: 0
-    - `size` (number, optional): Number of contacts per page (1-250). Default: 250
-
-- **get-vouchers**
-
-  - Get a list of bookkeeping vouchers (Eingangsbelege/Ausgangsbelege) from Lexware Office
-  - Inputs:
-    - `voucherType` (array of strings, optional): Filter by voucher type ("purchaseinvoice", "purchasecreditnote", "salesinvoice", "salescreditnote"). Default: all types
-    - `voucherStatus` (array of strings, optional): Filter by voucher status ("unchecked", "open", "paid", "paidoff", "voided", "transferred", "sepadebit"). Default: all statuses
-    - `page` (number, optional): Page number to retrieve (starts at 0). Default: 0
-    - `size` (number, optional): Number of vouchers per page (1-250). Default: 250
-
-- **get-voucher-details**
-
-  - Get details of a bookkeeping voucher from Lexware Office
-  - Inputs:
-    - `id` (string): The UUID of the voucher
-
-- **get-file**
-
-  - Download a file (PDF or XML) from Lexware Office by file ID
-  - Inputs:
-    - `id` (string): The UUID of the file (from `files.documentFileId` in voucher or invoice details)
-    - `format` (string, optional): File format to download ("pdf" or "xml"). Default: "pdf". Note: XML (XRechnung) is only available for specific invoice types.
-
-- **list-posting-categories**
-
-  - Retrieve list of posting categories for bookkeeping vouchers
-  - Inputs:
-    - `type` (string, optional): Filter posting categories by type ("income" or "outgo")
-
-- **list-countries**
-  - Retrieve list of countries known to lexoffice with their tax classifications
-  - Inputs:
-    - `taxClassification` (string, optional): Filter countries by tax classification ("de" for Germany, "intraCommunity" for EU countries, or "thirdPartyCountry" for non-EU countries)
+Example (draft mode — no finalization):
+```json
+{
+  "mcpServers": {
+    "lexware-office": {
+      "disabledTools": ["finalize-invoice", "finalize-dunning"]
+    }
+  }
+}
+```
 
 ## Configuration
 

--- a/docs/superpowers/plans/2026-04-18-wave-1-read-tools.md
+++ b/docs/superpowers/plans/2026-04-18-wave-1-read-tools.md
@@ -1,0 +1,551 @@
+# Wave 1: Fehlende Read-Tools – Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 14 neue read-only MCP-Tools für alle fehlenden Lexware-Office-Dokumenttypen implementieren.
+
+**Architecture:** Alle Tools folgen dem bestehenden Muster in `src/index.ts`: Zod-Schema → `makeLexwareOfficeRequest` → strukturierte Textantwort. Keine neuen Dateien, keine neue Abstraktionsschicht. Listen-Tools nutzen `/v1/voucherlist` mit `voucherType`-Filter; Detail-Tools nutzen den jeweiligen Typ-Endpunkt direkt.
+
+**Tech Stack:** TypeScript, Zod, `@modelcontextprotocol/sdk`, Lexware Office REST API
+
+---
+
+## Files
+
+- Modify: `src/index.ts` — 14 neue `server.tool(...)` Registrierungen hinzufügen
+
+---
+
+### Task 1: `get-quotations` + `get-quotation-details`
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: `get-quotations` implementieren**
+
+Füge nach dem letzten bestehenden Tool (vor `async function main()`) ein:
+
+```typescript
+server.tool(
+	'get-quotations',
+	'Get a list of quotations (Angebote) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'accepted', 'rejected', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'accepted', 'rejected', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=quotation&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No quotations found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} quotations in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+```
+
+- [ ] **Step 2: `get-quotation-details` implementieren**
+
+```typescript
+server.tool(
+	'get-quotation-details',
+	'Get details of a quotation (Angebot) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the quotation'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/quotations/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve quotation data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Quotation details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler, `build/index.js` wird erzeugt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: add get-quotations and get-quotation-details tools"
+```
+
+---
+
+### Task 2: `get-credit-notes` + `get-credit-note-details`
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: `get-credit-notes` implementieren**
+
+```typescript
+server.tool(
+	'get-credit-notes',
+	'Get a list of credit notes (Gutschriften) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'paid', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'paid', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=creditnote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No credit notes found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} credit notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+```
+
+- [ ] **Step 2: `get-credit-note-details` implementieren**
+
+```typescript
+server.tool(
+	'get-credit-note-details',
+	'Get details of a credit note (Gutschrift) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the credit note'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/credit-notes/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve credit note data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Credit note details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: add get-credit-notes and get-credit-note-details tools"
+```
+
+---
+
+### Task 3: `get-order-confirmations` + `get-delivery-notes` (je List + Detail)
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: `get-order-confirmations` implementieren**
+
+```typescript
+server.tool(
+	'get-order-confirmations',
+	'Get a list of order confirmations (Auftragsbestätigungen) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'fulfilled', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'fulfilled', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=orderconfirmation&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No order confirmations found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} order confirmations in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+```
+
+- [ ] **Step 2: `get-order-confirmation-details` implementieren**
+
+```typescript
+server.tool(
+	'get-order-confirmation-details',
+	'Get details of an order confirmation (Auftragsbestätigung) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the order confirmation'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/order-confirmations/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve order confirmation data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Order confirmation details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 3: `get-delivery-notes` implementieren**
+
+```typescript
+server.tool(
+	'get-delivery-notes',
+	'Get a list of delivery notes (Lieferscheine) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'fulfilled', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'fulfilled', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=deliverynote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No delivery notes found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} delivery notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+```
+
+- [ ] **Step 4: `get-delivery-note-details` implementieren**
+
+```typescript
+server.tool(
+	'get-delivery-note-details',
+	'Get details of a delivery note (Lieferschein) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the delivery note'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/delivery-notes/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve delivery note data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Delivery note details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: add get-order-confirmations and get-delivery-notes tools"
+```
+
+---
+
+### Task 4: `get-down-payment-invoice-details` + `get-profile` + `list-print-layouts`
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: `get-down-payment-invoice-details` implementieren**
+
+```typescript
+server.tool(
+	'get-down-payment-invoice-details',
+	'Get details of a down payment invoice (Anzahlungsrechnung) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the down payment invoice'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/down-payment-invoices/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve down payment invoice data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Down payment invoice details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 2: `get-profile` implementieren**
+
+```typescript
+server.tool(
+	'get-profile',
+	'Get the company profile (Unternehmensprofil) from Lexware Office, including company name, address, tax settings, and contact information',
+	{},
+	async () => {
+		const data = await makeLexwareOfficeRequest<any>('/v1/profile');
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve profile data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Company profile:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 3: `list-print-layouts` implementieren**
+
+```typescript
+server.tool(
+	'list-print-layouts',
+	'Retrieve available print layouts (Drucklayouts) from Lexware Office. Use these IDs when creating invoices or other documents to control the visual appearance.',
+	{},
+	async () => {
+		const data = await makeLexwareOfficeRequest<any>('/v1/print-layouts');
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve print layouts' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Print layouts:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: add get-down-payment-invoice-details, get-profile, list-print-layouts tools"
+```
+
+---
+
+### Task 5: `get-recurring-templates` + `get-articles` + `get-article-details`
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: `get-recurring-templates` implementieren**
+
+```typescript
+server.tool(
+	'get-recurring-templates',
+	'Get a list of recurring invoice templates (Wiederkehrende Vorlagen) from Lexware Office',
+	{
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ page, size }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/recurring-templates?page=${page}&size=${size}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve recurring templates' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Recurring templates:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 2: `get-articles` implementieren**
+
+```typescript
+server.tool(
+	'get-articles',
+	'Get a list of articles (Artikel/Produkte) from Lexware Office with optional filters',
+	{
+		articleNumber: z.string().optional().describe('Filter by article number (Artikelnummer)'),
+		name: z.string().optional().describe('Filter by article name (substring search)'),
+		type: z.enum(['PRODUCT', 'SERVICE']).optional().describe('Filter by article type'),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ articleNumber, name, type, page, size }) => {
+		const params = new URLSearchParams({ page: String(page), size: String(size) });
+		if (articleNumber) params.append('articleNumber', articleNumber);
+		if (name) params.append('name', name);
+		if (type) params.append('type', type);
+
+		const data = await makeLexwareOfficeRequest<any>(`/v1/articles?${params.toString()}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve articles' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Articles:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 3: `get-article-details` implementieren**
+
+```typescript
+server.tool(
+	'get-article-details',
+	'Get details of an article (Artikel/Produkt) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the article'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/articles/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve article data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Article details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: add get-recurring-templates, get-articles, get-article-details tools"
+```
+
+---
+
+### Task 6: Version bump + PR
+
+**Files:**
+- Modify: `package.json` — version `0.3.0` → `0.4.0`
+- Modify: `src/index.ts` — version im `McpServer`-Konstruktor anpassen
+
+- [ ] **Step 1: Version in `package.json` aktualisieren**
+
+In `package.json` ändern:
+```json
+"version": "0.4.0"
+```
+
+- [ ] **Step 2: Version in `src/index.ts` aktualisieren**
+
+Zeile 33 in `src/index.ts` ändern:
+```typescript
+const server = new McpServer({
+	name: 'lexware-office',
+	version: '0.4.0',
+});
+```
+
+- [ ] **Step 3: Final build**
+
+```bash
+npm run build
+```
+
+Expected: keine TypeScript-Fehler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json src/index.ts
+git commit -m "chore: bump version to 0.4.0 for Wave 1 release"
+```
+
+- [ ] **Step 5: Push + PR erstellen**
+
+```bash
+git push origin claude/angry-morse
+```
+
+Dann PR auf GitHub erstellen: `si0nDE/mcp-lexware-office`, Base: `main`, Head: `claude/angry-morse`.
+
+PR-Titel: `feat: Wave 1 — add 14 read-only tools for all missing document types`
+
+---
+
+## Hinweis: voucherType-Strings
+
+Die `voucherType`-Strings für den `/v1/voucherlist`-Endpunkt (`quotation`, `creditnote`, `orderconfirmation`, `deliverynote`) sind die wahrscheinlichsten Werte basierend auf dem API-Muster. Falls ein List-Tool `No ... found` zurückgibt obwohl Daten vorhanden sind, den tatsächlichen `voucherType`-String in der Lexware-API-Doku unter [voucherlist](https://developers.lexware.io/docs/#Lexware%20Office-api-documentation) verifizieren.

--- a/docs/superpowers/specs/2026-04-18-comprehensive-api-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-18-comprehensive-api-expansion-design.md
@@ -1,0 +1,147 @@
+# Design: Comprehensive API Expansion
+
+**Date:** 2026-04-18  
+**Status:** Approved  
+**Goal:** Vollständige Buchhaltung über Claude ermöglichen — alle API-Endpunkte von Lexware Office abdecken.
+
+---
+
+## Vision
+
+Der Nutzer soll seine gesamte Buchhaltung theoretisch durch Claude erledigen lassen können: Rechnungserstellung, Belegerfassung, Zahlungsverfolgung, Fehleranalyse und Automatisierungen — vollständig gesteuert über diesen MCP-Server.
+
+---
+
+## Architektur
+
+Alle neuen Tools folgen dem bestehenden Muster in `src/index.ts`:
+- Zod-Schema → `makeLexwareOfficeRequest` / `makeLexwareOfficeWriteRequest` → strukturierte Textantwort
+- Keine neuen Dateien, keine neue Abstraktionsschicht
+- Jedes Tool ist einzeln registriert, damit Claude Code-Permissions granular greifen
+
+---
+
+## Delivery: Wave-basiert (4 PRs)
+
+### Wave 1 — Fehlende Read-Tools
+
+14 neue Tools, alle nach gleichem Muster. Schnell umsetzbar, sofortiger Mehrwert.
+
+| Tool | Endpunkt | Anmerkung |
+|------|----------|-----------|
+| `get-quotations` | `GET /v1/voucherlist?voucherType=quotation` | Liste via voucherlist |
+| `get-quotation-details` | `GET /v1/quotations/{id}` | |
+| `get-credit-notes` | `GET /v1/voucherlist?voucherType=creditnote` | |
+| `get-credit-note-details` | `GET /v1/credit-notes/{id}` | |
+| `get-order-confirmations` | `GET /v1/voucherlist?voucherType=orderconfirmation` | |
+| `get-order-confirmation-details` | `GET /v1/order-confirmations/{id}` | |
+| `get-delivery-notes` | `GET /v1/voucherlist?voucherType=deliverynote` | |
+| `get-delivery-note-details` | `GET /v1/delivery-notes/{id}` | |
+| `get-down-payment-invoice-details` | `GET /v1/down-payment-invoices/{id}` | Nur Detail, kein List-Endpoint |
+| `get-profile` | `GET /v1/profile` | Unternehmensprofil |
+| `list-print-layouts` | `GET /v1/print-layouts` | |
+| `get-recurring-templates` | `GET /v1/recurring-templates` | |
+| `get-articles` | `GET /v1/articles` | Mit filter: name, articleNumber |
+| `get-article-details` | `GET /v1/articles/{id}` | |
+
+### Wave 2 — Write-Operationen für fehlende Dokumenttypen
+
+| Tool | Endpunkt |
+|------|----------|
+| `create-quotation` / `finalize-quotation` | `POST /v1/quotations[?finalize=true]` |
+| `create-credit-note` / `finalize-credit-note` | `POST /v1/credit-notes[?finalize=true]` |
+| `create-delivery-note` / `finalize-delivery-note` | `POST /v1/delivery-notes[?finalize=true]` |
+| `create-order-confirmation` / `finalize-order-confirmation` | `POST /v1/order-confirmations[?finalize=true]` |
+| `create-article` | `POST /v1/articles` |
+| `update-article` | `PUT /v1/articles/{id}` |
+| `delete-article` | `DELETE /v1/articles/{id}` |
+
+Hinweis: `delete-article` ist destruktiv und ein eigenes Tool — kann via `denyTools` in `settings.json` individuell gesperrt werden.
+
+### Wave 3 — File-Upload & PDF-Rendering
+
+| Tool | Endpunkt | Beschreibung |
+|------|----------|--------------|
+| `upload-file` | `POST /v1/files` | Datei hochladen (PDF/Bild) |
+| `attach-file-to-voucher` | `POST /v1/vouchers/{id}/files` | Datei an Voucher anhängen |
+| `render-document` | `GET /v1/{type}/{id}/document` | PDF rendern für alle Dokumenttypen (invoice, quotation, credit-note, dunning, delivery-note, order-confirmation) |
+
+### Wave 4 — Analyse-Tool & Event Subscriptions
+
+#### `analyze-bookings`
+
+Ein aggregierendes Tool, das intern mehrere API-Calls parallel macht und ein kompaktes Ergebnis zurückgibt. Token-freundlich: keine Rohdaten in den Kontext, nur verarbeitete Insights.
+
+**Parameter:**
+- `focus`: `all` (default) | `hygiene` | `cashflow`
+
+**Hygiene-Checks:**
+- Vouchers mit Status `unchecked` (noch nicht geprüft)
+- Vouchers ohne `contactId` (kein Lieferant/Kunde zugeordnet)
+- Vouchers ohne `voucherNumber` (fehlende Belegnummer)
+- Mögliche Duplikate: gleicher Betrag + gleicher Kontakt innerhalb von 30 Tagen
+
+**Cashflow-Checks:**
+- Offene Rechnungen nach Fälligkeit gruppiert (heute, 7 Tage, 30 Tage, überfällig)
+- Überfällige Rechnungen ohne existierende Mahnung → Mahnungsempfehlung
+- Anzahlungsrechnungen ohne folgende Hauptrechnung
+
+**Output-Struktur:**
+```json
+{
+  "hygiene": {
+    "uncheckedVouchers": 3,
+    "vouchersWithoutContact": 1,
+    "vouchersWithoutNumber": 2,
+    "possibleDuplicates": [
+      { "amount": 119.00, "contactId": "...", "dates": ["2026-04-01", "2026-04-03"] }
+    ]
+  },
+  "cashflow": {
+    "overdueInvoices": [
+      { "id": "...", "customerName": "...", "amount": 500.00, "daysOverdue": 14, "hasDunning": false }
+    ],
+    "dueSoon": { "today": 1, "7days": 2, "30days": 5 },
+    "dunningRecommendations": [
+      { "invoiceId": "...", "customerName": "...", "amount": 500.00, "daysOverdue": 14 }
+    ]
+  }
+}
+```
+
+#### Event Subscriptions (Webhooks)
+
+| Tool | Methode | Endpunkt |
+|------|---------|----------|
+| `create-event-subscription` | POST | `/v1/event-subscriptions` |
+| `list-event-subscriptions` | GET | `/v1/event-subscriptions` |
+| `get-event-subscription` | GET | `/v1/event-subscriptions/{id}` |
+| `delete-event-subscription` | DELETE | `/v1/event-subscriptions/{id}` |
+
+**Berechtigungsmodell:**  
+`delete-event-subscription` ist bewusst als eigenes Tool registriert (nicht gebündelt). Nutzer, die das Löschen von Webhooks verhindern wollen, können es in ihrer Claude Code `settings.json` explizit sperren:
+
+```json
+{
+  "denyTools": ["mcp__lexoffice-fieber-it__delete-event-subscription"]
+}
+```
+
+Das gleiche gilt für `delete-article`.
+
+---
+
+## Nicht über API verfügbar (strukturelle Grenzen)
+
+Diese Features können grundsätzlich nicht implementiert werden, solange Lexware Office sie nicht in die API aufnimmt:
+
+- Kontensalden / Summen-und-Saldenliste
+- GuV / Bilanz
+- Bankdaten / Kontoauszüge / Banktransaktionen
+- Planzahlen / Budget
+
+---
+
+## Offene Fragen
+
+Keine — alle Design-Entscheidungen sind getroffen und bestätigt.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mcp-lexware-office",
 	"description": "MCP server to interact with Lexware Office",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"license": "MIT",
 	"author": "Jannik Wempe <jannik@wempe.dev>",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mcp-lexware-office",
 	"description": "MCP server to interact with Lexware Office",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"license": "MIT",
 	"author": "Jannik Wempe <jannik@wempe.dev>",
 	"keywords": [

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -7,7 +7,7 @@ if (!LEXWARE_OFFICE_API_KEY) {
 }
 
 const LEXOFFICE_API_BASE = 'https://api.lexoffice.io';
-const USER_AGENT = 'mcp-lexware-office/0.2.0';
+const USER_AGENT = 'mcp-lexware-office/0.3.0';
 
 export async function makeLexwareOfficeRequest<T>(path: string): Promise<T | null> {
 	const url = `${LEXOFFICE_API_BASE}${path}`;
@@ -61,6 +61,55 @@ export async function makeLexwareOfficeFileRequest(
 		return { data, mimeType };
 	} catch (error) {
 		logger.error('Error making Lexware Office file request', { error });
+		return null;
+	}
+}
+
+export type WriteResult<T> =
+	| { ok: true; data: T }
+	| { ok: false; status: number; error: unknown };
+
+export async function makeLexwareOfficeWriteRequest<T>(
+	path: string,
+	method: 'POST' | 'PUT',
+	body: unknown,
+): Promise<WriteResult<T> | null> {
+	const url = `${LEXOFFICE_API_BASE}${path}`;
+	const headers = {
+		'User-Agent': USER_AGENT,
+		'Content-Type': 'application/json',
+		Accept: 'application/json',
+		Authorization: `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+	};
+
+	logger.log('Making Lexware Office write request', { url, method });
+
+	try {
+		const response = await fetch(url, {
+			method,
+			headers,
+			body: JSON.stringify(body),
+		});
+
+		let responseBody: unknown;
+		try {
+			responseBody = await response.json();
+		} catch {
+			responseBody = null;
+		}
+
+		if (!response.ok) {
+			logger.error('Lexware Office write request failed', {
+				status: response.status,
+				error: responseBody,
+			});
+			return { ok: false, status: response.status, error: responseBody };
+		}
+
+		logger.log('Lexware Office write response', { status: response.status });
+		return { ok: true, data: responseBody as T };
+	} catch (error) {
+		logger.error('Error making Lexware Office write request', { error });
 		return null;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,16 +538,18 @@ server.tool(
 		note: z.string().optional(),
 	},
 	async ({ id, customer, vendor, companyName, taxNumber, vatRegistrationId, firstName, lastName, salutation, note, version }) => {
-		const apiRoles =
-			customer !== undefined || vendor !== undefined
-				? {
-						...(customer ? { customer: {} } : {}),
-						...(vendor ? { vendor: {} } : {}),
-					}
-				: undefined;
+		if (!customer && !vendor) {
+			return {
+				content: [{ type: 'text', text: 'Error: Lexoffice requires at least one role. Set customer or vendor to "true".' }],
+			};
+		}
+		const apiRoles = {
+			...(customer ? { customer: {} } : {}),
+			...(vendor ? { vendor: {} } : {}),
+		};
 		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/contacts/${id}`, 'PUT', {
 			version,
-			...(apiRoles !== undefined ? { roles: apiRoles } : {}),
+			roles: apiRoles,
 			...(companyName
 				? { company: { name: companyName, ...(taxNumber ? { taxNumber } : {}), ...(vatRegistrationId ? { vatRegistrationId } : {}) } }
 				: {}),
@@ -611,6 +613,13 @@ const invoiceSchema = {
 	taxConditions: z.object({
 		taxType: z.enum(['net', 'gross', 'vatfree']).describe('"net" = Netto, "gross" = Brutto, "vatfree" = steuerfrei'),
 	}),
+	shippingConditions: z.object({
+		shippingDate: z.string().describe('Service/delivery date in ISO 8601 format'),
+		shippingEndDate: z.string().optional().describe('End date for period types (serviceperiod/deliveryperiod)'),
+		shippingType: z
+			.enum(['service', 'delivery', 'serviceperiod', 'deliveryperiod'])
+			.describe('"service" = Leistungsdatum, "delivery" = Lieferdatum, "serviceperiod" = Leistungszeitraum, "deliveryperiod" = Lieferzeitraum'),
+	}).describe('Service/delivery conditions — required by Lexoffice API'),
 	paymentConditions: z
 		.object({
 			paymentTermLabelLanguage: z.enum(['de', 'en']).optional(),
@@ -678,6 +687,11 @@ const dunningSchema = {
 	taxConditions: z.object({
 		taxType: z.enum(['net', 'gross', 'vatfree']),
 	}),
+	shippingConditions: z.object({
+		shippingDate: z.string().describe('Service/delivery date in ISO 8601 format'),
+		shippingEndDate: z.string().optional(),
+		shippingType: z.enum(['service', 'delivery', 'serviceperiod', 'deliveryperiod']),
+	}).describe('Required by Lexoffice API'),
 	introduction: z.string().optional(),
 	remark: z.string().optional(),
 };
@@ -686,9 +700,14 @@ async function handleDunningRequest(
 	params: Record<string, unknown>,
 	finalize: boolean,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
-	const path = finalize ? '/v1/dunnings?finalize=true' : '/v1/dunnings';
+	const { precedingSalesVoucherId, ...rest } = params;
+	const queryParams = new URLSearchParams({
+		precedingSalesVoucherId: precedingSalesVoucherId as string,
+		...(finalize ? { finalize: 'true' } : {}),
+	});
+	const path = `/v1/dunnings?${queryParams.toString()}`;
 	const body = {
-		...params,
+		...rest,
 		totalPrice: { currency: 'EUR' },
 	};
 	const result = await makeLexwareOfficeWriteRequest<any>(path, 'POST', body);
@@ -732,15 +751,18 @@ server.tool(
 				'Voucher type: purchaseinvoice (Eingangsrechnung), purchasecreditnote (Eingangsgutschrift), salesinvoice (Ausgangsrechnung), salescreditnote (Ausgangsgutschrift)',
 			),
 		voucherDate: z.string().describe('Voucher date in ISO 8601 format, e.g. "2026-03-22T00:00:00.000+01:00"'),
+		voucherNumber: z.string().optional().describe("The supplier's invoice number as printed on the document"),
 		dueDate: z.string().optional().describe('Due date in ISO 8601 format'),
-		supplierQuoteNumber: z.string().optional().describe('External invoice number from the supplier'),
 		contactId: z.string().uuid().optional().describe('Reference to an existing contact (Lieferant/Kunde)'),
 		remark: z.string().optional().describe('Internal note'),
+		taxType: z
+			.enum(['net', 'gross', 'vatfree'])
+			.describe('"net" = Netto, "gross" = Brutto, "vatfree" = steuerfrei'),
 		voucherItems: z
 			.array(
 				z.object({
-					amount: z.string().describe('Gross amount as string, e.g. "119.00"'),
-					taxAmount: z.string().describe('Tax amount as string, e.g. "19.00"'),
+					amount: z.number().describe('Gross amount, e.g. 119.00'),
+					taxAmount: z.number().describe('Tax amount, e.g. 19.00'),
 					taxRatePercent: z.number().describe('Tax rate: 0, 7, or 19'),
 					categoryId: z
 						.string()
@@ -751,7 +773,13 @@ server.tool(
 			.min(1),
 	},
 	async (params) => {
-		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', params);
+		const totalGrossAmount = params.voucherItems.reduce((sum, item) => sum + item.amount, 0);
+		const totalTaxAmount = params.voucherItems.reduce((sum, item) => sum + item.taxAmount, 0);
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', {
+			...params,
+			totalGrossAmount,
+			totalTaxAmount,
+		});
 
 		if (!result || !result.ok) {
 			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
@@ -776,15 +804,16 @@ server.tool(
 		version: z.number().int().describe('Current version of the voucher (for optimistic locking)'),
 		type: z.enum(['purchaseinvoice', 'purchasecreditnote', 'salesinvoice', 'salescreditnote']),
 		voucherDate: z.string().describe('Voucher date in ISO 8601 format'),
+		voucherNumber: z.string().optional().describe("The supplier's invoice number as printed on the document"),
 		dueDate: z.string().optional(),
-		supplierQuoteNumber: z.string().optional(),
 		contactId: z.string().uuid().optional(),
 		remark: z.string().optional(),
+		taxType: z.enum(['net', 'gross', 'vatfree']),
 		voucherItems: z
 			.array(
 				z.object({
-					amount: z.string().describe('Gross amount as string, e.g. "119.00"'),
-					taxAmount: z.string().describe('Tax amount as string, e.g. "19.00"'),
+					amount: z.number().describe('Gross amount, e.g. 119.00'),
+					taxAmount: z.number().describe('Tax amount, e.g. 19.00'),
 					taxRatePercent: z.number(),
 					categoryId: z.string().uuid(),
 				}),
@@ -792,7 +821,13 @@ server.tool(
 			.min(1),
 	},
 	async ({ id, ...body }) => {
-		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/vouchers/${id}`, 'PUT', body);
+		const totalGrossAmount = body.voucherItems.reduce((sum, item) => sum + item.amount, 0);
+		const totalTaxAmount = body.voucherItems.reduce((sum, item) => sum + item.taxAmount, 0);
+		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/vouchers/${id}`, 'PUT', {
+			...body,
+			totalGrossAmount,
+			totalTaxAmount,
+		});
 
 		if (!result || !result.ok) {
 			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };

--- a/src/index.ts
+++ b/src/index.ts
@@ -844,6 +844,54 @@ server.tool(
 	},
 );
 
+server.tool(
+	'get-quotations',
+	'Get a list of quotations (Angebote) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'accepted', 'rejected', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'accepted', 'rejected', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=quotation&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No quotations found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} quotations in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+
+server.tool(
+	'get-quotation-details',
+	'Get details of a quotation (Angebot) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the quotation'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/quotations/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve quotation data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Quotation details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { logger } from './logger.js';
 
 const server = new McpServer({
 	name: 'lexware-office',
-	version: '0.2.0',
+	version: '0.3.0',
 });
 
 server.tool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,6 +892,54 @@ server.tool(
 	},
 );
 
+	server.tool(
+		'get-credit-notes',
+		'Get a list of credit notes (Gutschriften) from Lexware Office',
+		{
+			status: z
+				.array(z.enum(['draft', 'open', 'paid', 'voided']))
+				.optional()
+				.default(['draft', 'open', 'paid', 'voided']),
+			page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+			size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+		},
+		async ({ status, page, size }) => {
+			const url = `/v1/voucherlist?voucherType=creditnote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+			const data = await makeLexwareOfficeRequest<any>(url);
+			const vouchers = data?.content;
+
+			if (!vouchers || vouchers.length === 0) {
+				return { content: [{ type: 'text', text: 'No credit notes found' }] };
+			}
+
+			return {
+				content: [{
+					type: 'text',
+					text: `There are ${data.totalElements} credit notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+				}],
+			};
+		},
+	);
+
+	server.tool(
+		'get-credit-note-details',
+		'Get details of a credit note (Gutschrift) from Lexware Office by its ID',
+		{
+			id: z.string().uuid().describe('The ID of the credit note'),
+		},
+		async ({ id }) => {
+			const data = await makeLexwareOfficeRequest<any>(`/v1/credit-notes/${id}`);
+
+			if (!data) {
+				return { content: [{ type: 'text', text: 'Failed to retrieve credit note data' }] };
+			}
+
+			return {
+				content: [{ type: 'text', text: `Credit note details:\n\n${JSON.stringify(data, null, 2)}` }],
+			};
+		},
+	);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -763,6 +763,93 @@ server.tool(
 	async (params) => handleDunningRequest(params, true),
 );
 
+server.tool(
+	'create-voucher',
+	'Create a new bookkeeping voucher (Buchungsbeleg) in Lexware Office, e.g. an incoming invoice (Eingangsrechnung). Use list-posting-categories to find valid categoryId values.',
+	{
+		type: z
+			.enum(['purchaseinvoice', 'purchasecreditnote', 'salesinvoice', 'salescreditnote'])
+			.describe(
+				'Voucher type: purchaseinvoice (Eingangsrechnung), purchasecreditnote (Eingangsgutschrift), salesinvoice (Ausgangsrechnung), salescreditnote (Ausgangsgutschrift)',
+			),
+		voucherDate: z.string().describe('Voucher date in ISO 8601 format, e.g. "2026-03-22T00:00:00.000+01:00"'),
+		dueDate: z.string().optional().describe('Due date in ISO 8601 format'),
+		supplierQuoteNumber: z.string().optional().describe('External invoice number from the supplier'),
+		contactId: z.string().uuid().optional().describe('Reference to an existing contact (Lieferant/Kunde)'),
+		remark: z.string().optional().describe('Internal note'),
+		voucherItems: z
+			.array(
+				z.object({
+					amount: z.string().describe('Gross amount as string, e.g. "119.00"'),
+					taxAmount: z.string().describe('Tax amount as string, e.g. "19.00"'),
+					taxRatePercent: z.number().describe('Tax rate: 0, 7, or 19'),
+					categoryId: z
+						.string()
+						.uuid()
+						.describe('Posting category ID from list-posting-categories'),
+				}),
+			)
+			.min(1),
+	},
+	async (params) => {
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', params);
+
+		if (!result || !result.ok) {
+			return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Voucher created successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
+server.tool(
+	'update-voucher',
+	'Update an existing bookkeeping voucher in Lexware Office. Requires the current version number (get it from get-voucher-details). All fields from create-voucher are required.',
+	{
+		id: z.string().uuid().describe('The ID of the voucher to update'),
+		version: z.number().int().describe('Current version of the voucher (for optimistic locking)'),
+		type: z.enum(['purchaseinvoice', 'purchasecreditnote', 'salesinvoice', 'salescreditnote']),
+		voucherDate: z.string().describe('Voucher date in ISO 8601 format'),
+		dueDate: z.string().optional(),
+		supplierQuoteNumber: z.string().optional(),
+		contactId: z.string().uuid().optional(),
+		remark: z.string().optional(),
+		voucherItems: z
+			.array(
+				z.object({
+					amount: z.string().describe('Gross amount as string, e.g. "119.00"'),
+					taxAmount: z.string().describe('Tax amount as string, e.g. "19.00"'),
+					taxRatePercent: z.number(),
+					categoryId: z.string().uuid(),
+				}),
+			)
+			.min(1),
+	},
+	async ({ id, ...body }) => {
+		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/vouchers/${id}`, 'PUT', body);
+
+		if (!result || !result.ok) {
+			return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Voucher updated successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1089,6 +1089,73 @@ server.tool(
 	},
 );
 
+server.tool(
+	'get-recurring-templates',
+	'Get a list of recurring invoice templates (Wiederkehrende Vorlagen) from Lexware Office',
+	{
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ page, size }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/recurring-templates?page=${page}&size=${size}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve recurring templates' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Recurring templates:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
+	'get-articles',
+	'Get a list of articles (Artikel/Produkte) from Lexware Office with optional filters',
+	{
+		articleNumber: z.string().optional().describe('Filter by article number (Artikelnummer)'),
+		name: z.string().optional().describe('Filter by article name (substring search)'),
+		type: z.enum(['PRODUCT', 'SERVICE']).optional().describe('Filter by article type'),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ articleNumber, name, type, page, size }) => {
+		const params = new URLSearchParams({ page: String(page), size: String(size) });
+		if (articleNumber) params.append('articleNumber', articleNumber);
+		if (name) params.append('name', name);
+		if (type) params.append('type', type);
+
+		const data = await makeLexwareOfficeRequest<any>(`/v1/articles?${params.toString()}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve articles' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Articles:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
+	'get-article-details',
+	'Get details of an article (Artikel/Produkt) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the article'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/articles/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve article data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Article details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1036,6 +1036,59 @@ server.tool(
 	},
 );
 
+server.tool(
+	'get-down-payment-invoice-details',
+	'Get details of a down payment invoice (Anzahlungsrechnung) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the down payment invoice'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/down-payment-invoices/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve down payment invoice data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Down payment invoice details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
+	'get-profile',
+	'Get the company profile (Unternehmensprofil) from Lexware Office, including company name, address, tax settings, and contact information',
+	{},
+	async () => {
+		const data = await makeLexwareOfficeRequest<any>('/v1/profile');
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve profile data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Company profile:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
+	'list-print-layouts',
+	'Retrieve available print layouts (Drucklayouts) from Lexware Office. Use these IDs when creating invoices or other documents to control the visual appearance.',
+	{},
+	async () => {
+		const data = await makeLexwareOfficeRequest<any>('/v1/print-layouts');
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve print layouts' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Print layouts:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ function writeErrorResponse(result: { status: number; error: unknown } | null): 
 
 const server = new McpServer({
 	name: 'lexware-office',
-	version: '0.3.0',
+	version: '0.4.0',
 });
 
 server.tool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,6 +393,56 @@ server.tool(
 	},
 );
 
+server.tool(
+	'get-payments',
+	'Get payment information for an invoice or voucher from Lexware Office. Returns payment history including amounts, dates, and payment method.',
+	{
+		id: z.string().uuid().describe('The ID of the invoice or voucher to retrieve payment information for'),
+	},
+	async ({ id }) => {
+		const paymentsData = await makeLexwareOfficeRequest<any>(`/v1/payments?openItemId=${id}`);
+
+		if (!paymentsData) {
+			return {
+				content: [{ type: 'text', text: 'Failed to retrieve payment information' }],
+			};
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Payment information:\n\n${JSON.stringify(paymentsData, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
+server.tool(
+	'get-payment-conditions',
+	'Retrieve available payment conditions (Zahlungsbedingungen) from Lexware Office. Use these as reference when creating invoices.',
+	{},
+	async () => {
+		const data = await makeLexwareOfficeRequest<any>('/v1/payment-conditions');
+
+		if (!data) {
+			return {
+				content: [{ type: 'text', text: 'Failed to retrieve payment conditions' }],
+			};
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Payment conditions:\n\n${JSON.stringify(data, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -525,7 +525,7 @@ server.tool(
 
 		if (!result || !result.ok) {
 			return {
-				content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }],
+				content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }],
 			};
 		}
 
@@ -598,7 +598,7 @@ server.tool(
 
 		if (!result || !result.ok) {
 			return {
-				content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }],
+				content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }],
 			};
 		}
 
@@ -669,7 +669,7 @@ const invoiceSchema = {
 };
 
 async function handleInvoiceRequest(
-	params: any,
+	params: Record<string, unknown>,
 	finalize: boolean,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
 	const path = finalize ? '/v1/invoices?finalize=true' : '/v1/invoices';
@@ -680,7 +680,7 @@ async function handleInvoiceRequest(
 	const result = await makeLexwareOfficeWriteRequest<any>(path, 'POST', body);
 
 	if (!result || !result.ok) {
-		return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+		return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
 	}
 
 	const action = finalize ? 'created and finalized' : 'created as draft';
@@ -724,7 +724,7 @@ const dunningSchema = {
 };
 
 async function handleDunningRequest(
-	params: any,
+	params: Record<string, unknown>,
 	finalize: boolean,
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
 	const path = finalize ? '/v1/dunnings?finalize=true' : '/v1/dunnings';
@@ -735,7 +735,7 @@ async function handleDunningRequest(
 	const result = await makeLexwareOfficeWriteRequest<any>(path, 'POST', body);
 
 	if (!result || !result.ok) {
-		return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+		return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
 	}
 
 	const action = finalize ? 'created and finalized' : 'created as draft';
@@ -795,7 +795,7 @@ server.tool(
 		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', params);
 
 		if (!result || !result.ok) {
-			return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
 		}
 
 		return {
@@ -836,7 +836,7 @@ server.tool(
 		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/vouchers/${id}`, 'PUT', body);
 
 		if (!result || !result.ok) {
-			return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
 		}
 
 		return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,32 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 
-import { makeLexwareOfficeRequest, makeLexwareOfficeFileRequest } from './helper.js';
+import { makeLexwareOfficeRequest, makeLexwareOfficeFileRequest, makeLexwareOfficeWriteRequest } from './helper.js';
 import { logger } from './logger.js';
+
+const contactPersonSchema = z.object({
+	salutation: z.string().optional(),
+	firstName: z.string().optional(),
+	lastName: z.string(),
+	emailAddress: z.string().optional(),
+	phoneNumber: z.string().optional(),
+});
+
+const addressEntrySchema = z.object({
+	street: z.string().optional(),
+	zip: z.string().optional(),
+	city: z.string().optional(),
+	countryCode: z.string().length(2).optional(),
+	supplement: z.string().optional(),
+});
+
+function writeErrorResponse(result: { status: number; error: unknown } | null): string {
+	if (!result) return 'Request failed due to a network or server error.';
+	if (result.status === 404) return 'Record not found.';
+	if (result.status === 409) return 'Version conflict — please re-fetch the record and try again.';
+	if (result.status === 401 || result.status === 403) return 'Authentication or permission error.';
+	return `API error (${result.status}): ${JSON.stringify(result.error, null, 2)}`;
+}
 
 const server = new McpServer({
 	name: 'lexware-office',
@@ -437,6 +461,152 @@ server.tool(
 				{
 					type: 'text',
 					text: `Payment conditions:\n\n${JSON.stringify(data, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
+server.tool(
+	'create-contact',
+	'Create a new contact (customer or vendor) in Lexware Office.',
+	{
+		roles: z
+			.object({
+				customer: z.object({}).optional().describe('Include to assign the customer role'),
+				vendor: z.object({}).optional().describe('Include to assign the vendor role'),
+			})
+			.optional(),
+		company: z
+			.object({
+				name: z.string(),
+				taxNumber: z.string().optional(),
+				vatRegistrationId: z.string().optional(),
+				contactPersons: z.array(contactPersonSchema).optional(),
+			})
+			.optional()
+			.describe('Company details — provide either company or person, not both'),
+		person: z
+			.object({
+				salutation: z.string().optional(),
+				firstName: z.string().optional(),
+				lastName: z.string(),
+			})
+			.optional()
+			.describe('Person details — provide either company or person, not both'),
+		addresses: z
+			.object({
+				billing: z.array(addressEntrySchema).optional(),
+				shipping: z.array(addressEntrySchema).optional(),
+			})
+			.optional(),
+		emailAddresses: z
+			.object({
+				business: z.array(z.string()).optional(),
+				office: z.array(z.string()).optional(),
+				private: z.array(z.string()).optional(),
+				other: z.array(z.string()).optional(),
+			})
+			.optional(),
+		phoneNumbers: z
+			.object({
+				business: z.array(z.string()).optional(),
+				office: z.array(z.string()).optional(),
+				mobile: z.array(z.string()).optional(),
+				private: z.array(z.string()).optional(),
+				fax: z.array(z.string()).optional(),
+				other: z.array(z.string()).optional(),
+			})
+			.optional(),
+		note: z.string().optional(),
+	},
+	async (params) => {
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/contacts', 'POST', params);
+
+		if (!result || !result.ok) {
+			return {
+				content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }],
+			};
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Contact created successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
+				},
+			],
+		};
+	},
+);
+
+server.tool(
+	'update-contact',
+	'Update an existing contact in Lexware Office. Requires the current version number for optimistic locking (get it from get-contacts).',
+	{
+		id: z.string().uuid().describe('The ID of the contact to update'),
+		version: z.number().int().describe('Current version of the contact (for optimistic locking)'),
+		roles: z
+			.object({
+				customer: z.object({}).optional(),
+				vendor: z.object({}).optional(),
+			})
+			.optional(),
+		company: z
+			.object({
+				name: z.string(),
+				taxNumber: z.string().optional(),
+				vatRegistrationId: z.string().optional(),
+				contactPersons: z.array(contactPersonSchema).optional(),
+			})
+			.optional(),
+		person: z
+			.object({
+				salutation: z.string().optional(),
+				firstName: z.string().optional(),
+				lastName: z.string(),
+			})
+			.optional(),
+		addresses: z
+			.object({
+				billing: z.array(addressEntrySchema).optional(),
+				shipping: z.array(addressEntrySchema).optional(),
+			})
+			.optional(),
+		emailAddresses: z
+			.object({
+				business: z.array(z.string()).optional(),
+				office: z.array(z.string()).optional(),
+				private: z.array(z.string()).optional(),
+				other: z.array(z.string()).optional(),
+			})
+			.optional(),
+		phoneNumbers: z
+			.object({
+				business: z.array(z.string()).optional(),
+				office: z.array(z.string()).optional(),
+				mobile: z.array(z.string()).optional(),
+				private: z.array(z.string()).optional(),
+				fax: z.array(z.string()).optional(),
+				other: z.array(z.string()).optional(),
+			})
+			.optional(),
+		note: z.string().optional(),
+	},
+	async ({ id, ...body }) => {
+		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/contacts/${id}`, 'PUT', body);
+
+		if (!result || !result.ok) {
+			return {
+				content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }],
+			};
+		}
+
+		return {
+			content: [
+				{
+					type: 'text',
+					text: `Contact updated successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
 				},
 			],
 		};

--- a/src/index.ts
+++ b/src/index.ts
@@ -940,6 +940,102 @@ server.tool(
 	},
 );
 
+server.tool(
+	'get-order-confirmations',
+	'Get a list of order confirmations (Auftragsbestätigungen) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'fulfilled', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'fulfilled', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=orderconfirmation&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No order confirmations found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} order confirmations in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+
+server.tool(
+	'get-order-confirmation-details',
+	'Get details of an order confirmation (Auftragsbestätigung) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the order confirmation'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/order-confirmations/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve order confirmation data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Order confirmation details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
+	'get-delivery-notes',
+	'Get a list of delivery notes (Lieferscheine) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'fulfilled', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'fulfilled', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=deliverynote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
+
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No delivery notes found' }] };
+		}
+
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} delivery notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
+
+server.tool(
+	'get-delivery-note-details',
+	'Get details of a delivery note (Lieferschein) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the delivery note'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/delivery-notes/${id}`);
+
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve delivery note data' }] };
+		}
+
+		return {
+			content: [{ type: 'text', text: `Delivery note details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,53 +892,53 @@ server.tool(
 	},
 );
 
-	server.tool(
-		'get-credit-notes',
-		'Get a list of credit notes (Gutschriften) from Lexware Office',
-		{
-			status: z
-				.array(z.enum(['draft', 'open', 'paid', 'voided']))
-				.optional()
-				.default(['draft', 'open', 'paid', 'voided']),
-			page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
-			size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
-		},
-		async ({ status, page, size }) => {
-			const url = `/v1/voucherlist?voucherType=creditnote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
-			const data = await makeLexwareOfficeRequest<any>(url);
-			const vouchers = data?.content;
+server.tool(
+	'get-credit-notes',
+	'Get a list of credit notes (Gutschriften) from Lexware Office',
+	{
+		status: z
+			.array(z.enum(['draft', 'open', 'paid', 'voided']))
+			.optional()
+			.default(['draft', 'open', 'paid', 'voided']),
+		page: z.number().min(0).optional().default(0).describe('page number to retrieve; starts at 0'),
+		size: z.number().min(1).max(250).optional().default(250).describe('number of results per page'),
+	},
+	async ({ status, page, size }) => {
+		const url = `/v1/voucherlist?voucherType=creditnote&voucherStatus=${status.join(',')}&page=${page}&size=${size}`;
+		const data = await makeLexwareOfficeRequest<any>(url);
+		const vouchers = data?.content;
 
-			if (!vouchers || vouchers.length === 0) {
-				return { content: [{ type: 'text', text: 'No credit notes found' }] };
-			}
+		if (!vouchers || vouchers.length === 0) {
+			return { content: [{ type: 'text', text: 'No credit notes found' }] };
+		}
 
-			return {
-				content: [{
-					type: 'text',
-					text: `There are ${data.totalElements} credit notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
-				}],
-			};
-		},
-	);
+		return {
+			content: [{
+				type: 'text',
+				text: `There are ${data.totalElements} credit notes in total (showing ${vouchers.length} on page ${page}):\n\n${JSON.stringify(vouchers, null, 2)}`,
+			}],
+		};
+	},
+);
 
-	server.tool(
-		'get-credit-note-details',
-		'Get details of a credit note (Gutschrift) from Lexware Office by its ID',
-		{
-			id: z.string().uuid().describe('The ID of the credit note'),
-		},
-		async ({ id }) => {
-			const data = await makeLexwareOfficeRequest<any>(`/v1/credit-notes/${id}`);
+server.tool(
+	'get-credit-note-details',
+	'Get details of a credit note (Gutschrift) from Lexware Office by its ID',
+	{
+		id: z.string().uuid().describe('The ID of the credit note'),
+	},
+	async ({ id }) => {
+		const data = await makeLexwareOfficeRequest<any>(`/v1/credit-notes/${id}`);
 
-			if (!data) {
-				return { content: [{ type: 'text', text: 'Failed to retrieve credit note data' }] };
-			}
+		if (!data) {
+			return { content: [{ type: 'text', text: 'Failed to retrieve credit note data' }] };
+		}
 
-			return {
-				content: [{ type: 'text', text: `Credit note details:\n\n${JSON.stringify(data, null, 2)}` }],
-			};
-		},
-	);
+		return {
+			content: [{ type: 'text', text: `Credit note details:\n\n${JSON.stringify(data, null, 2)}` }],
+		};
+	},
+);
 
 async function main() {
 	const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -708,6 +708,61 @@ server.tool(
 	async (params) => handleInvoiceRequest(params, true),
 );
 
+const dunningSchema = {
+	precedingSalesVoucherId: z
+		.string()
+		.uuid()
+		.describe('ID of the invoice this dunning is for (from get-invoices or get-invoice-details)'),
+	voucherDate: z.string().describe('Dunning date in ISO 8601 format, e.g. "2026-03-22T00:00:00.000+01:00"'),
+	address: invoiceAddressSchema,
+	lineItems: z.array(lineItemSchema).min(1),
+	taxConditions: z.object({
+		taxType: z.enum(['net', 'gross', 'vatfree']),
+	}),
+	introduction: z.string().optional(),
+	remark: z.string().optional(),
+};
+
+async function handleDunningRequest(
+	params: any,
+	finalize: boolean,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+	const path = finalize ? '/v1/dunnings?finalize=true' : '/v1/dunnings';
+	const body = {
+		...params,
+		totalPrice: { currency: 'EUR' },
+	};
+	const result = await makeLexwareOfficeWriteRequest<any>(path, 'POST', body);
+
+	if (!result || !result.ok) {
+		return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+	}
+
+	const action = finalize ? 'created and finalized' : 'created as draft';
+	return {
+		content: [
+			{
+				type: 'text',
+				text: `Dunning ${action} successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
+			},
+		],
+	};
+}
+
+server.tool(
+	'create-dunning',
+	'Create a dunning notice (Mahnung) as a draft in Lexware Office for an existing invoice. Use finalize-dunning to create and immediately finalize.',
+	dunningSchema,
+	async (params) => handleDunningRequest(params, false),
+);
+
+server.tool(
+	'finalize-dunning',
+	'Create and immediately finalize a dunning notice (Mahnung) in Lexware Office for an existing invoice. The dunning will be locked and cannot be edited.',
+	dunningSchema,
+	async (params) => handleDunningRequest(params, true),
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -613,6 +613,101 @@ server.tool(
 	},
 );
 
+const lineItemSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.enum(['material', 'service', 'custom']),
+		name: z.string().describe('Line item description'),
+		quantity: z.number().describe('Quantity'),
+		unitName: z.string().describe('Unit name, e.g. "Stunden", "Stück"'),
+		unitPrice: z.object({
+			currency: z.literal('EUR'),
+			netAmount: z.string().describe('Net amount as string, e.g. "9.99"'),
+			taxRatePercentage: z.number().describe('Tax rate, e.g. 19 for 19%'),
+		}),
+		discountPercentage: z.number().min(0).max(100).optional(),
+	}),
+	z.object({
+		type: z.literal('text'),
+		name: z.string().describe('Free text line (no price or quantity)'),
+	}),
+]);
+
+const invoiceAddressSchema = z.union([
+	z.object({
+		contactId: z.string().uuid().describe('Reference to an existing contact'),
+	}),
+	z.object({
+		name: z.string(),
+		street: z.string().optional(),
+		zip: z.string().optional(),
+		city: z.string().optional(),
+		countryCode: z.string().length(2).describe('ISO 3166-1 alpha-2, e.g. "DE"'),
+	}),
+]);
+
+const invoiceSchema = {
+	voucherDate: z.string().describe('Invoice date in ISO 8601 format, e.g. "2026-03-22T00:00:00.000+01:00"'),
+	address: invoiceAddressSchema,
+	lineItems: z.array(lineItemSchema).min(1),
+	taxConditions: z.object({
+		taxType: z.enum(['net', 'gross', 'vatfree']).describe('"net" = Netto, "gross" = Brutto, "vatfree" = steuerfrei'),
+	}),
+	paymentConditions: z
+		.object({
+			paymentTermLabelLanguage: z.enum(['de', 'en']).optional(),
+			paymentTermDuration: z.number().int().describe('Payment term in days'),
+			paymentDiscountConditions: z
+				.object({
+					discountPercentage: z.number(),
+					discountRange: z.number().int().describe('Days within which discount applies'),
+				})
+				.optional(),
+		})
+		.optional(),
+	introduction: z.string().optional().describe('Introductory text before line items'),
+	remark: z.string().optional().describe('Closing text after line items'),
+};
+
+async function handleInvoiceRequest(
+	params: any,
+	finalize: boolean,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+	const path = finalize ? '/v1/invoices?finalize=true' : '/v1/invoices';
+	const body = {
+		...params,
+		totalPrice: { currency: 'EUR' },
+	};
+	const result = await makeLexwareOfficeWriteRequest<any>(path, 'POST', body);
+
+	if (!result || !result.ok) {
+		return { content: [{ type: 'text', text: writeErrorResponse(result ? { status: result.status, error: result.error } : null) }] };
+	}
+
+	const action = finalize ? 'created and finalized' : 'created as draft';
+	return {
+		content: [
+			{
+				type: 'text',
+				text: `Invoice ${action} successfully:\n\n${JSON.stringify(result.data, null, 2)}`,
+			},
+		],
+	};
+}
+
+server.tool(
+	'create-invoice',
+	'Create a new invoice as a draft in Lexware Office. The invoice will not be sent to the customer. Use finalize-invoice to create and immediately finalize.',
+	invoiceSchema,
+	async (params) => handleInvoiceRequest(params, false),
+);
+
+server.tool(
+	'finalize-invoice',
+	'Create and immediately finalize (publish) an invoice in Lexware Office. The invoice will be locked and cannot be edited. Use create-invoice to create a draft first.',
+	invoiceSchema,
+	async (params) => handleInvoiceRequest(params, true),
+);
+
 async function main() {
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,21 +424,30 @@ server.tool(
 		id: z.string().uuid().describe('The ID of the invoice or voucher to retrieve payment information for'),
 	},
 	async ({ id }) => {
-		const paymentsData = await makeLexwareOfficeRequest<any>(`/v1/payments?openItemId=${id}`);
+		const LEXOFFICE_API_BASE = 'https://api.lexoffice.io';
+		const LEXWARE_OFFICE_API_KEY = process.env.LEXWARE_OFFICE_API_KEY!;
+		const response = await fetch(`${LEXOFFICE_API_BASE}/v1/payments/${id}`, {
+			headers: {
+				Accept: 'application/json',
+				Authorization: `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+			},
+		}).catch(() => null);
 
-		if (!paymentsData) {
+		if (!response) {
+			return { content: [{ type: 'text', text: 'Network error retrieving payment information' }] };
+		}
+
+		let body: unknown;
+		try { body = await response.json(); } catch { body = null; }
+
+		if (!response.ok) {
 			return {
-				content: [{ type: 'text', text: 'Failed to retrieve payment information' }],
+				content: [{ type: 'text', text: `API error ${response.status}: ${JSON.stringify(body)}` }],
 			};
 		}
 
 		return {
-			content: [
-				{
-					type: 'text',
-					text: `Payment information:\n\n${JSON.stringify(paymentsData, null, 2)}`,
-				},
-			],
+			content: [{ type: 'text', text: `Payment information:\n\n${JSON.stringify(body, null, 2)}` }],
 		};
 	},
 );
@@ -469,59 +478,31 @@ server.tool(
 
 server.tool(
 	'create-contact',
-	'Create a new contact (customer or vendor) in Lexware Office.',
+	'Create a new contact in Lexware Office. Provide companyName for a company contact, or firstName/lastName for a person. Set customer and/or vendor to true.',
 	{
-		roles: z
-			.object({
-				customer: z.object({}).optional().describe('Include to assign the customer role'),
-				vendor: z.object({}).optional().describe('Include to assign the vendor role'),
-			})
-			.optional(),
-		company: z
-			.object({
-				name: z.string(),
-				taxNumber: z.string().optional(),
-				vatRegistrationId: z.string().optional(),
-				contactPersons: z.array(contactPersonSchema).optional(),
-			})
-			.optional()
-			.describe('Company details — provide either company or person, not both'),
-		person: z
-			.object({
-				salutation: z.string().optional(),
-				firstName: z.string().optional(),
-				lastName: z.string(),
-			})
-			.optional()
-			.describe('Person details — provide either company or person, not both'),
-		addresses: z
-			.object({
-				billing: z.array(addressEntrySchema).optional(),
-				shipping: z.array(addressEntrySchema).optional(),
-			})
-			.optional(),
-		emailAddresses: z
-			.object({
-				business: z.array(z.string()).optional(),
-				office: z.array(z.string()).optional(),
-				private: z.array(z.string()).optional(),
-				other: z.array(z.string()).optional(),
-			})
-			.optional(),
-		phoneNumbers: z
-			.object({
-				business: z.array(z.string()).optional(),
-				office: z.array(z.string()).optional(),
-				mobile: z.array(z.string()).optional(),
-				private: z.array(z.string()).optional(),
-				fax: z.array(z.string()).optional(),
-				other: z.array(z.string()).optional(),
-			})
-			.optional(),
+		customer: z.string().optional().transform(v => v === 'true').describe('Set to "true" to assign the customer role'),
+		vendor: z.string().optional().transform(v => v === 'true').describe('Set to "true" to assign the vendor role'),
+		companyName: z.string().optional().describe('Company name — provide either companyName or lastName, not both'),
+		taxNumber: z.string().optional().describe('Tax number of the company'),
+		vatRegistrationId: z.string().optional().describe('VAT registration ID of the company'),
+		firstName: z.string().optional().describe('First name — for person contacts'),
+		lastName: z.string().optional().describe('Last name — for person contacts; required if companyName is not provided'),
+		salutation: z.string().optional().describe('Salutation for person contacts'),
 		note: z.string().optional(),
 	},
-	async (params) => {
-		const result = await makeLexwareOfficeWriteRequest<any>('/v1/contacts', 'POST', params);
+	async ({ customer, vendor, companyName, taxNumber, vatRegistrationId, firstName, lastName, salutation, note }) => {
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/contacts', 'POST', {
+			version: 0,
+			roles: {
+				...(customer ? { customer: {} } : {}),
+				...(vendor ? { vendor: {} } : {}),
+			},
+			...(companyName
+				? { company: { name: companyName, ...(taxNumber ? { taxNumber } : {}), ...(vatRegistrationId ? { vatRegistrationId } : {}) } }
+				: {}),
+			...(lastName || firstName ? { person: { ...(salutation ? { salutation } : {}), ...(firstName ? { firstName } : {}), ...(lastName ? { lastName } : {}) } } : {}),
+			...(note ? { note } : {}),
+		});
 
 		if (!result || !result.ok) {
 			return {
@@ -546,55 +527,33 @@ server.tool(
 	{
 		id: z.string().uuid().describe('The ID of the contact to update'),
 		version: z.number().int().describe('Current version of the contact (for optimistic locking)'),
-		roles: z
-			.object({
-				customer: z.object({}).optional(),
-				vendor: z.object({}).optional(),
-			})
-			.optional(),
-		company: z
-			.object({
-				name: z.string(),
-				taxNumber: z.string().optional(),
-				vatRegistrationId: z.string().optional(),
-				contactPersons: z.array(contactPersonSchema).optional(),
-			})
-			.optional(),
-		person: z
-			.object({
-				salutation: z.string().optional(),
-				firstName: z.string().optional(),
-				lastName: z.string(),
-			})
-			.optional(),
-		addresses: z
-			.object({
-				billing: z.array(addressEntrySchema).optional(),
-				shipping: z.array(addressEntrySchema).optional(),
-			})
-			.optional(),
-		emailAddresses: z
-			.object({
-				business: z.array(z.string()).optional(),
-				office: z.array(z.string()).optional(),
-				private: z.array(z.string()).optional(),
-				other: z.array(z.string()).optional(),
-			})
-			.optional(),
-		phoneNumbers: z
-			.object({
-				business: z.array(z.string()).optional(),
-				office: z.array(z.string()).optional(),
-				mobile: z.array(z.string()).optional(),
-				private: z.array(z.string()).optional(),
-				fax: z.array(z.string()).optional(),
-				other: z.array(z.string()).optional(),
-			})
-			.optional(),
+		customer: z.string().optional().transform(v => v === 'true').describe('Set to "true" to assign the customer role'),
+		vendor: z.string().optional().transform(v => v === 'true').describe('Set to "true" to assign the vendor role'),
+		companyName: z.string().optional().describe('Company name'),
+		taxNumber: z.string().optional().describe('Tax number of the company'),
+		vatRegistrationId: z.string().optional().describe('VAT registration ID of the company'),
+		firstName: z.string().optional().describe('First name — for person contacts'),
+		lastName: z.string().optional().describe('Last name — for person contacts'),
+		salutation: z.string().optional().describe('Salutation for person contacts'),
 		note: z.string().optional(),
 	},
-	async ({ id, ...body }) => {
-		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/contacts/${id}`, 'PUT', body);
+	async ({ id, customer, vendor, companyName, taxNumber, vatRegistrationId, firstName, lastName, salutation, note, version }) => {
+		const apiRoles =
+			customer !== undefined || vendor !== undefined
+				? {
+						...(customer ? { customer: {} } : {}),
+						...(vendor ? { vendor: {} } : {}),
+					}
+				: undefined;
+		const result = await makeLexwareOfficeWriteRequest<any>(`/v1/contacts/${id}`, 'PUT', {
+			version,
+			...(apiRoles !== undefined ? { roles: apiRoles } : {}),
+			...(companyName
+				? { company: { name: companyName, ...(taxNumber ? { taxNumber } : {}), ...(vatRegistrationId ? { vatRegistrationId } : {}) } }
+				: {}),
+			...(lastName || firstName ? { person: { ...(salutation ? { salutation } : {}), ...(firstName ? { firstName } : {}), ...(lastName ? { lastName } : {}) } } : {}),
+			...(note ? { note } : {}),
+		});
 
 		if (!result || !result.ok) {
 			return {


### PR DESCRIPTION
## Overview

Extends the Lexware Office MCP server with 12 new tools for write access, payment information, and file downloads.

### New Tools

**Payment & Reference Data (2):**
- `get-payments` — Retrieve payment history (partial payments, dates, methods) for any invoice or voucher
- `get-payment-conditions` — List available payment terms for use when creating invoices

**Contacts (2):**
- `create-contact` — Create new customer and/or vendor contact
- `update-contact` — Update existing contact (with optimistic locking via version field)

**Invoices (2):**
- `create-invoice` — Create invoice as draft
- `finalize-invoice` — Create and immediately finalize invoice (separate tool so it can be excluded per MCP config)

**Dunnings (2):**
- `create-dunning` — Create dunning notice as draft from a preceding invoice
- `finalize-dunning` — Create and immediately finalize dunning notice

**Vouchers (2):**
- `create-voucher` — Create bookkeeping voucher (Buchungsbeleg)
- `update-voucher` — Update existing voucher

**Files (1):**
- `get-file` — Download PDF or XML files (e.g. invoice PDFs) by document ID

### Design Decisions

- **Draft/finalize split**: Create and finalize tools are intentionally separate so operators can grant or deny finalization rights via MCP config (closes #1)
- **Flat parameter schemas**: Contact tools use flat top-level params (`companyName`, `firstName`, `customer`, `vendor`) instead of nested objects — nested objects caused MCP SDK JSON schema validation errors that prevented models from passing values correctly
- **String-to-boolean transform**: Role flags use `z.string().transform(v => v === 'true')` to work around MCP framework's strict JSON schema validation which rejects string inputs for boolean fields before Zod coercion can run
- **Payment endpoint**: Uses `GET /v1/payments/{id}` path parameter (not query param); returns full partial payment history including dates, amounts, and payment methods

## Test plan

- [x] `get-payment-conditions` — returns available payment terms
- [x] `get-payments` — returns partial payment history for invoices (tested with 8-installment invoice)
- [x] `create-contact` — successfully creates company contact with customer/vendor roles
- [x] `create-invoice` / `finalize-invoice` — tested; fixed: `shippingConditions` was missing from schema
- [x] `create-dunning` / `finalize-dunning` — tested; fixed: `shippingConditions` missing + `precedingSalesVoucherId` must be query param not body
- [x] `create-voucher` / `update-voucher` — tested; fixed: `taxType` at root level, `amount`/`taxAmount` as numbers, `totalGrossAmount`/`totalTaxAmount` auto-computed, `supplierQuoteNumber` → `voucherNumber`
- [x] `update-contact` — tested; fixed: now returns clear error when no role provided
- [x] `get-file` — PDF download works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)