### PR TITLE
feat: add duplicate-voucher tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An MCP server implementation that integrates with Lexware Office (formerly known
 
 ## Features
 
-- **Broad Lexware Office API coverage**: 53 tools covering the available read/write workflows exposed by this server
+- **Broad Lexware Office API coverage**: 56 tools covering the available read/write workflows exposed by this server
 - **Full document lifecycle**: Create, finalize, and download PDFs for invoices, quotations, order confirmations, credit notes, delivery notes, and dunning notices
 - **Contact management**: Create, read, and update customers and vendors
 - **Bookkeeping**: Vouchers, posting categories, payments, and file uploads
@@ -65,6 +65,7 @@ An MCP server implementation that integrates with Lexware Office (formerly known
 ### Down-Payment Invoices
 | Tool | Description | API |
 |---|---|---|
+| `get-down-payment-invoices` | List down-payment invoices with optional filters | `GET /v1/down-payment-invoices` |
 | `get-down-payment-invoice-details` | Get details of a specific down-payment invoice | `GET /v1/down-payment-invoices/{id}` |
 
 ### Contacts
@@ -82,6 +83,7 @@ An MCP server implementation that integrates with Lexware Office (formerly known
 | `get-voucher-details` | Get details of a specific voucher | `GET /v1/vouchers/{id}` |
 | `create-voucher` | Create a bookkeeping voucher (e.g. incoming invoice) | `POST /v1/vouchers` |
 | `update-voucher` | Update an existing bookkeeping voucher | `PUT /v1/vouchers/{id}` |
+| `duplicate-voucher` | Duplicate a voucher including all file attachments | `GET + POST /v1/vouchers` |
 | `list-posting-categories` | List posting categories for bookkeeping | `GET /v1/posting-categories` |
 
 ### Articles (Product Catalogue)
@@ -101,11 +103,12 @@ An MCP server implementation that integrates with Lexware Office (formerly known
 | `upload-file` | Upload a file and receive a file ID | `POST /v1/files` |
 | `upload-file-to-voucher` | Upload a file and attach it to a voucher | `POST /v1/vouchers/{id}/files` |
 
-### Payments
+### Payments & Receivables
 | Tool | Description | API |
 |---|---|---|
 | `get-payments` | Get payment information for an invoice or voucher | `GET /v1/payments` |
 | `get-payment-conditions` | List available payment conditions (Zahlungsbedingungen) | `GET /v1/payment-conditions` |
+| `get-open-receivables` | Get all open receivables for a customer (invoices + salesinvoice vouchers combined) | `GET /v1/invoices` + `GET /v1/voucherlist` |
 
 ### Recurring Templates
 | Tool | Description | API |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1358,6 +1358,94 @@ server.tool(
 );
 
 server.tool(
+	'duplicate-voucher',
+	'Duplicates an existing bookkeeping voucher including all file attachments. Equivalent to "Beleg duplizieren" in Lexware Office UI.',
+	{
+		sourceVoucherId: z.string().uuid().describe('ID of the voucher to duplicate'),
+		voucherNumber: z.string().optional().describe("New voucher number (e.g. 'INV-2024-05'). If omitted, Lexware auto-assigns (useful for sales vouchers with sequential numbering)."),
+		voucherDate: z.string().optional().describe('Voucher date in ISO 8601 format. If omitted, copied from source.'),
+		dueDate: z.string().optional().describe('Due date in ISO 8601 format. If omitted, copied from source.'),
+		voucherStatus: z.enum(['unchecked', 'open']).optional().default('open').describe("Status of the new voucher. Default: 'open'."),
+	},
+	async ({ sourceVoucherId, voucherNumber, voucherDate, dueDate, voucherStatus }) => {
+		const LEXOFFICE_API_BASE = 'https://api.lexware.io';
+		const LEXWARE_OFFICE_API_KEY = process.env.LEXWARE_OFFICE_API_KEY!;
+
+		const source = await makeLexwareOfficeRequest<any>(`/v1/vouchers/${sourceVoucherId}`);
+		if (!source) {
+			return { content: [{ type: 'text', text: `Failed to fetch source voucher ${sourceVoucherId} — not found or inaccessible.` }] };
+		}
+
+		const body: Record<string, unknown> = {
+			type: source.type,
+			taxType: source.taxType,
+			voucherItems: source.voucherItems,
+			voucherDate: voucherDate ?? source.voucherDate,
+			voucherStatus,
+		};
+		if (voucherNumber !== undefined) body.voucherNumber = voucherNumber;
+		if (dueDate !== undefined) body.dueDate = dueDate;
+		else if (source.dueDate !== undefined) body.dueDate = source.dueDate;
+		if (source.contactId !== undefined) body.contactId = source.contactId;
+		if (source.remark !== undefined) body.remark = source.remark;
+
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', body);
+		if (!result || !result.ok) {
+			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
+		}
+		const newId: string = result.data.id;
+
+		const sourceFileIds: string[] = Array.isArray(source.files) ? source.files : [];
+		const fileWarnings: string[] = [];
+		let attachedFiles = 0;
+
+		for (const fileId of sourceFileIds) {
+			try {
+				const downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
+					headers: {
+						'Accept': '*/*',
+						'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+					},
+				});
+				if (!downloadResponse.ok) {
+					fileWarnings.push(`${fileId} (download failed: ${downloadResponse.status})`);
+					continue;
+				}
+				const contentType = downloadResponse.headers.get('content-type') ?? 'application/pdf';
+				const contentDisposition = downloadResponse.headers.get('content-disposition') ?? '';
+				const filename = contentDisposition.match(/filename="?([^";\n]+)"?/)?.[1] ?? `${fileId}.pdf`;
+				const fileBuffer = await downloadResponse.arrayBuffer();
+				const blob = new Blob([fileBuffer], { type: contentType });
+				const formData = new FormData();
+				formData.append('file', blob, filename);
+				const uploadResult = await makeLexwareOfficeMultipartRequest<any>(`/v1/vouchers/${newId}/files`, formData);
+				if (!uploadResult || !uploadResult.ok) {
+					fileWarnings.push(`${fileId} (upload failed)`);
+				} else {
+					attachedFiles++;
+				}
+			} catch {
+				fileWarnings.push(`${fileId} (error)`);
+			}
+		}
+
+		const summary: Record<string, unknown> = {
+			id: newId,
+			voucherNumber: result.data.voucherNumber,
+			voucherDate: result.data.voucherDate ?? body.voucherDate,
+			totalGrossAmount: result.data.totalGrossAmount,
+			attachedFiles,
+			sourceVoucherId,
+		};
+		if (fileWarnings.length > 0) summary.fileWarnings = fileWarnings;
+
+		return {
+			content: [{ type: 'text', text: `Voucher duplicated successfully:\n\n${JSON.stringify(summary, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
 	'get-quotations',
 	'Get a list of quotations (Angebote) from Lexware Office',
 	{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1380,6 +1380,8 @@ server.tool(
 			type: source.type,
 			taxType: source.taxType,
 			voucherItems: source.voucherItems,
+			totalGrossAmount: source.totalGrossAmount,
+			totalTaxAmount: source.totalTaxAmount,
 			voucherDate: voucherDate ?? source.voucherDate,
 			voucherStatus,
 		};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1403,12 +1403,17 @@ server.tool(
 
 		for (const fileId of sourceFileIds) {
 			try {
-				const downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
-					headers: {
-						'Accept': '*/*',
-						'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
-					},
-				});
+				let downloadResponse!: Response;
+				for (let attempt = 0; attempt < 4; attempt++) {
+					if (attempt > 0) await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** (attempt - 1)));
+					downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
+						headers: {
+							'Accept': '*/*',
+							'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+						},
+					});
+					if (downloadResponse.status !== 429) break;
+				}
 				if (!downloadResponse.ok) {
 					fileWarnings.push(`${fileId} (download failed: ${downloadResponse.status})`);
 					continue;


### PR DESCRIPTION
## Summary

- Adds `duplicate-voucher` tool that atomically copies a source voucher's fields and all file attachments into a new voucher — equivalent to "Beleg duplizieren" in Lexware Office UI
- Fixes README: adds missing `get-down-payment-invoices` and `get-open-receivables` tools, updates tool count to 56

## Details

**`duplicate-voucher` parameters:**
- `sourceVoucherId` (required) — ID of the voucher to copy
- `voucherNumber` (optional) — new number; if omitted, Lexware auto-assigns (useful for sales vouchers with sequential numbering)
- `voucherDate` (optional) — falls back to source date if omitted
- `dueDate` (optional) — falls back to source due date if omitted
- `voucherStatus` (optional) — `unchecked` or `open`, defaults to `open`

**Implementation notes:**
- `totalGrossAmount`/`totalTaxAmount` copied verbatim from source — API requires both fields explicitly
- File transfer reuses the raw-fetch pattern from `update-voucher` (`Accept: */*`, filename from `content-disposition`, multipart upload)
- File copy failures warn but do not abort — voucher always created; `fileWarnings` array only present when > 0 failures
- Retry with exponential backoff (1s/2s/4s, up to 3 retries) on 429 rate-limit errors during file download

## Test plan

- [x] Call `duplicate-voucher` with a known voucher ID and new `voucherNumber`/`voucherDate`
- [x] Verify new voucher appears in Lexware Office with correct fields and line items
- [x] Verify all file attachments from source are present on new voucher
- [x] Verify source voucher is unchanged
- [ ] ~~Verify omitting `voucherNumber` works for a salesinvoice (auto-numbering)~~ — N/A: no salesinvoice available as test source; logic is consistent with `create-voucher`