### PR TITLE
feat: add duplicate-voucher tool (v1) + duplicateVoucher workflow (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The v1 server exposes one MCP tool per common Lexware workflow. This is easy to 
 - `create-voucher`
 - `finalize-invoice`
 - `upload-file-to-voucher`
+- `duplicate-voucher`
 
 See the full v1 tool list in [docs/version-guide.md#v1-tool-surface](docs/version-guide.md#v1-tool-surface).
 
@@ -47,6 +48,8 @@ The v2 server exposes a smaller MCP surface:
 
 - `search` — runs a sandboxed JavaScript async arrow function against a curated OpenAPI-lite Lexware catalog.
 - `execute` — runs a sandboxed JavaScript async arrow function with one host capability, `lexware.request`, for relative `/v1/...` Lexware API calls.
+
+The catalog (`spec.workflows`) includes curated recipes such as `duplicateVoucher` (field-only duplication; file re-attachment requires v1) and reporting helpers. Run `search` with `async () => Object.keys(spec.workflows)` to list all available workflows.
 
 Example v2 `execute` call:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1358,6 +1358,94 @@ server.tool(
 );
 
 server.tool(
+	'duplicate-voucher',
+	'Duplicates an existing bookkeeping voucher including all file attachments. Equivalent to "Beleg duplizieren" in Lexware Office UI.',
+	{
+		sourceVoucherId: z.string().uuid().describe('ID of the voucher to duplicate'),
+		voucherNumber: z.string().optional().describe("New voucher number (e.g. 'INV-2024-05'). If omitted, Lexware auto-assigns (useful for sales vouchers with sequential numbering)."),
+		voucherDate: z.string().optional().describe('Voucher date in ISO 8601 format. If omitted, copied from source.'),
+		dueDate: z.string().optional().describe('Due date in ISO 8601 format. If omitted, copied from source.'),
+		voucherStatus: z.enum(['unchecked', 'open']).optional().default('open').describe("Status of the new voucher. Default: 'open'."),
+	},
+	async ({ sourceVoucherId, voucherNumber, voucherDate, dueDate, voucherStatus }) => {
+		const LEXOFFICE_API_BASE = 'https://api.lexware.io';
+		const LEXWARE_OFFICE_API_KEY = process.env.LEXWARE_OFFICE_API_KEY!;
+
+		const source = await makeLexwareOfficeRequest<any>(`/v1/vouchers/${sourceVoucherId}`);
+		if (!source) {
+			return { content: [{ type: 'text', text: `Failed to fetch source voucher ${sourceVoucherId} — not found or inaccessible.` }] };
+		}
+
+		const body: Record<string, unknown> = {
+			type: source.type,
+			taxType: source.taxType,
+			voucherItems: source.voucherItems,
+			voucherDate: voucherDate ?? source.voucherDate,
+			voucherStatus,
+		};
+		if (voucherNumber !== undefined) body.voucherNumber = voucherNumber;
+		if (dueDate !== undefined) body.dueDate = dueDate;
+		else if (source.dueDate !== undefined) body.dueDate = source.dueDate;
+		if (source.contactId !== undefined) body.contactId = source.contactId;
+		if (source.remark !== undefined) body.remark = source.remark;
+
+		const result = await makeLexwareOfficeWriteRequest<any>('/v1/vouchers', 'POST', body);
+		if (!result || !result.ok) {
+			return { content: [{ type: 'text', text: writeErrorResponse(result && !result.ok ? result : null) }] };
+		}
+		const newId: string = result.data.id;
+
+		const sourceFileIds: string[] = Array.isArray(source.files) ? source.files : [];
+		const fileWarnings: string[] = [];
+		let attachedFiles = 0;
+
+		for (const fileId of sourceFileIds) {
+			try {
+				const downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
+					headers: {
+						'Accept': '*/*',
+						'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+					},
+				});
+				if (!downloadResponse.ok) {
+					fileWarnings.push(`${fileId} (download failed: ${downloadResponse.status})`);
+					continue;
+				}
+				const contentType = downloadResponse.headers.get('content-type') ?? 'application/pdf';
+				const contentDisposition = downloadResponse.headers.get('content-disposition') ?? '';
+				const filename = contentDisposition.match(/filename="?([^";\n]+)"?/)?.[1] ?? `${fileId}.pdf`;
+				const fileBuffer = await downloadResponse.arrayBuffer();
+				const blob = new Blob([fileBuffer], { type: contentType });
+				const formData = new FormData();
+				formData.append('file', blob, filename);
+				const uploadResult = await makeLexwareOfficeMultipartRequest<any>(`/v1/vouchers/${newId}/files`, formData);
+				if (!uploadResult || !uploadResult.ok) {
+					fileWarnings.push(`${fileId} (upload failed)`);
+				} else {
+					attachedFiles++;
+				}
+			} catch {
+				fileWarnings.push(`${fileId} (error)`);
+			}
+		}
+
+		const summary: Record<string, unknown> = {
+			id: newId,
+			voucherNumber: result.data.voucherNumber,
+			voucherDate: result.data.voucherDate ?? body.voucherDate,
+			totalGrossAmount: result.data.totalGrossAmount,
+			attachedFiles,
+			sourceVoucherId,
+		};
+		if (fileWarnings.length > 0) summary.fileWarnings = fileWarnings;
+
+		return {
+			content: [{ type: 'text', text: `Voucher duplicated successfully:\n\n${JSON.stringify(summary, null, 2)}` }],
+		};
+	},
+);
+
+server.tool(
 	'get-quotations',
 	'Get a list of quotations (Angebote) from Lexware Office',
 	{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1380,6 +1380,8 @@ server.tool(
 			type: source.type,
 			taxType: source.taxType,
 			voucherItems: source.voucherItems,
+			totalGrossAmount: source.totalGrossAmount,
+			totalTaxAmount: source.totalTaxAmount,
 			voucherDate: voucherDate ?? source.voucherDate,
 			voucherStatus,
 		};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1403,12 +1403,17 @@ server.tool(
 
 		for (const fileId of sourceFileIds) {
 			try {
-				const downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
-					headers: {
-						'Accept': '*/*',
-						'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
-					},
-				});
+				let downloadResponse!: Response;
+				for (let attempt = 0; attempt < 4; attempt++) {
+					if (attempt > 0) await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** (attempt - 1)));
+					downloadResponse = await fetch(`${LEXOFFICE_API_BASE}/v1/files/${fileId}`, {
+						headers: {
+							'Accept': '*/*',
+							'Authorization': `Bearer ${LEXWARE_OFFICE_API_KEY}`,
+						},
+					});
+					if (downloadResponse.status !== 429) break;
+				}
 				if (!downloadResponse.ok) {
 					fileWarnings.push(`${fileId} (download failed: ${downloadResponse.status})`);
 					continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1026,10 +1026,17 @@ const lineItemSchema = z.discriminatedUnion('type', [
 
 const invoiceAddressSchema = z.union([
 	z.object({
-		contactId: z.string().uuid().describe('Reference to an existing contact'),
+		contactId: z.string().uuid().describe('Reference to an existing contact. The optional fields below are "deviated address" overrides applied to this document only — the contact\'s stored data is not modified.'),
+		name: z.string().optional().describe('Override name for this document only'),
+		supplement: z.string().optional().describe('Override address supplement (Adresszusatz)'),
+		street: z.string().optional().describe('Override street and house number'),
+		zip: z.string().optional().describe('Override postal code'),
+		city: z.string().optional().describe('Override city'),
+		countryCode: z.string().length(2).optional().describe('Override country code (ISO 3166-1 alpha-2, e.g. "DE")'),
 	}),
 	z.object({
-		name: z.string(),
+		name: z.string().describe('Required when no contactId is provided'),
+		supplement: z.string().optional(),
 		street: z.string().optional(),
 		zip: z.string().optional(),
 		city: z.string().optional(),
@@ -1066,6 +1073,8 @@ const invoiceSchema = {
 		.optional(),
 	introduction: z.string().optional().describe('Introductory text before line items'),
 	remark: z.string().optional().describe('Closing text after line items'),
+	language: z.enum(['de', 'en']).optional().describe('Document language — affects all print labels, document title, and default text modules. "de" = German (default), "en" = English (renders "Invoice", "Net", "VAT", etc.)'),
+	title: z.string().optional().describe('Custom document title on the printed voucher. Uses organization default if omitted (e.g. "Rechnung"). Example: "Pro Forma Invoice", "Amended Invoice".'),
 };
 
 async function handleInvoiceRequest(
@@ -1126,6 +1135,8 @@ const dunningSchema = {
 	}).describe('Required by Lexoffice API'),
 	introduction: z.string().optional(),
 	remark: z.string().optional(),
+	language: z.enum(['de', 'en']).optional().describe('Document language — affects all print labels, document title, and default text modules. "de" = German (default), "en" = English.'),
+	title: z.string().optional().describe('Custom document title on the printed voucher. Uses organization default if omitted.'),
 };
 
 async function handleDunningRequest(
@@ -1977,6 +1988,8 @@ const deliveryNoteSchema = {
 	}).describe('Shipping/delivery conditions — required by Lexoffice API'),
 	introduction: z.string().optional().describe('Introductory text before line items'),
 	remark: z.string().optional().describe('Closing text after line items'),
+	language: z.enum(['de', 'en']).optional().describe('Document language — affects all print labels, document title, and default text modules. "de" = German (default), "en" = English.'),
+	title: z.string().optional().describe('Custom document title on the printed voucher. Uses organization default if omitted.'),
 };
 
 async function handleDeliveryNoteRequest(

--- a/src/v2/lexware-spec.ts
+++ b/src/v2/lexware-spec.ts
@@ -914,6 +914,28 @@ export const lexwareSpec: LexwareApiCatalog = {
 				{ method: 'GET', path: '/v1/contacts/{id}' },
 			],
 		},
+		duplicateVoucher: {
+			summary: 'Duplicate a bookkeeping voucher (Beleg duplizieren) — copy fields to a new voucher',
+			keywords: ['duplicate', 'copy voucher', 'duplicate voucher', 'Beleg duplizieren', 'Beleg kopieren', 'clone voucher'],
+			steps: [
+				'Fetch the source voucher with GET /v1/vouchers/{id}.',
+				'Build the new POST body from source fields: type, taxType, voucherItems, totalGrossAmount, totalTaxAmount, voucherDate (override if provided by user), dueDate (copied or overridden), contactId, remark. Strip id, version, createdDate, updatedDate, and files[] — do not include them.',
+				'POST /v1/vouchers with the assembled body and desired voucherStatus (open or unchecked; default to open).',
+				'File re-attachment (source.files[]) is not possible in v2 execute: GET /v1/files/{id} returns binary-metadata only ({binary: true, omitted: true}) — the sandbox never receives file bytes. Use the v1 duplicate-voucher tool when full file re-attachment is required.',
+			],
+			relatedEndpoints: [
+				{ method: 'GET', path: '/v1/vouchers/{id}' },
+				{ method: 'POST', path: '/v1/vouchers' },
+				{ method: 'GET', path: '/v1/files/{id}' },
+				{ method: 'POST', path: '/v1/vouchers/{id}/files' },
+			],
+			notes: [
+				'totalGrossAmount and totalTaxAmount must be included in the POST body even though they are derived; the API rejects requests without them.',
+				'contactId and remark may be absent in the source — omit from the POST body rather than sending null.',
+				'voucherNumber can be omitted to let Lexware auto-assign sequential numbering (recommended for salesinvoice and salescreditnote).',
+				'Binary file re-attachment is not supported in v2 execute: v2 drops binary response bodies. For full duplication including attachments, use the v1 duplicate-voucher tool.',
+			],
+		},
 	},
 };
 


### PR DESCRIPTION
## Summary

- **v1** (`src/index.ts`): Adds `duplicate-voucher` tool — reads a source bookkeeping voucher, creates a new one with the same fields (overridable date/number/status), and re-attaches all file attachments. Equivalent to "Beleg duplizieren" in the Lexware Office UI.
- **v2** (`src/v2/lexware-spec.ts`): Adds `duplicateVoucher` entry to `spec.workflows` — documents the field-copy steps and the binary file limitation (v2 execute cannot receive binary file bytes from GET /v1/files/{id}, so full file re-attachment requires the v1 tool).
- **README**: Documents `duplicate-voucher` in the v1 tool list and the `duplicateVoucher` workflow in the v2 section.
- **Schema fixes** (`src/index.ts`): Two schema-gap fixes included since they affect the same file and share the same root cause (Zod schemas not fully mirroring the Lexware API's writable field surface):
  - **Deviated address** (`invoiceAddressSchema`): When a `contactId` is provided alongside address fields, the overrides were silently stripped — only `contactId` was forwarded. Added Mode 2 support so all address fields are passed through as-is. The contact's stored data is never modified.
  - **`language` and `title` fields**: Missing from `invoiceSchema`, `dunningSchema`, and `deliveryNoteSchema`. Both fields are documented writable fields in the Lexware API. `language` controls the document locale (`"de"` / `"en"`); `title` overrides the default document title (e.g. "Rechnung").

## v1 Implementation Details

- Supported types: `purchaseinvoice`, `purchasecreditnote`, `salesinvoice`, `salescreditnote`
- Parameters: `sourceVoucherId` (required), `voucherDate`, `dueDate`, `voucherNumber`, `voucherStatus` (default: `open`)
- File attachment copy: sequential download → multipart re-upload per file; 429 retry with exponential backoff (up to 4 attempts); per-file failures collected as warnings without rolling back the created voucher
- `totalGrossAmount` / `totalTaxAmount` copied explicitly (API requires them in the POST body even though they are derived fields)
- `voucherNumber` optional — omitting lets Lexware auto-assign (recommended for salesinvoice/salescreditnote sequential numbering)

## v2 Notes

The `duplicateVoucher` workflow entry covers field-only duplication. File re-attachment is not possible in v2 execute because `GET /v1/files/{id}` returns `{ binary: true, omitted: true }` — the sandbox never receives file bytes. The workflow notes call this out explicitly and recommend the v1 tool for full duplication including attachments.

## Test plan

- [ ] `pnpm run build` exits 0
- [ ] Create a test bookkeeping voucher with a PDF attachment in Lexware Office sandbox/account
- [ ] Call v1 `duplicate-voucher` with `sourceVoucherId` — verify new voucher created with same line items and file attachment copied
- [ ] Call v2 `search` with `async () => spec.workflows.duplicateVoucher` — verify workflow entry returned with correct steps and notes
- [x] Call `create-invoice` with `contactId` + address override fields — verify deviated address is applied to the document (contact stored address unchanged)
- [x] Call `create-invoice` with `language: "en"` — verify document title renders as "Invoice" and labels are in English
- [x] Call `create-invoice` with `title: "Pro Forma Invoice"` — verify custom title appears on document